### PR TITLE
Add Docker image to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@
 version: 2
 jobs:
   build-and-deploy-job:
+    docker:
+      - image: ubuntu/artful
+
     working_directory: ~/repo
 
     steps:


### PR DESCRIPTION
This changeset adds a Docker image as all CircleCI builds require an executor type.