### PR TITLE
Remove global fractal install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
       - run:
           name: Install Node.js Dependencies
           command: |
-            npm install -g @frctl/fractal
             npm install
             npm run build
 


### PR DESCRIPTION
This changeset removes the global fractal install instruction as we should not need it.  It is already defined in package.json.