### PR TITLE
Add missing line from deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
       - deploy:
           name: Deploy Pattern Library
           command: |
+            export PATH=$HOME/bin:$PATH
             ./bin/cf_deploy.sh fec-pattern-library fec-beta-fec dev
 
 workflows:


### PR DESCRIPTION
This changeset adds a missing line to configure the PATH environment variable so that the CF CLI tool can be found.