### PR TITLE
Add debugging for missing style errors to repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If this happens, you may see the following error message:
 
 If this happens, double-check that things you are trying to import in the pattern library actually exist in `fec-cms`.
 Look in https://github.com/18F/fec-cms/tree/develop/fec/fec/static/scss/components for the component specified by the error message.
-If you don’t find the component there, you can safely remove it from  […]/fec-pattern-library/static/scss/styles.scss on your branch, then save and execute `npm run build` again. The error message should no longer appear. 
+If you don’t find the component there, you can safely remove it from `[…]/fec-pattern-library/static/scss/styles.scss` on your branch, then save and execute `npm run build` again. The error message should no longer appear. 
 
 ## Front end asset management for components
 Component specific SCSS and JavaScript files are contained in the `public/` folder, and compiled files and assets are be served from the `public/` folder.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Build JavaScript only:
 npm run-build-js
 ```
 
+### Debugging
+
+Since the `fec-cms` repository is a dependency to this pattern library, there may be discrepancies between style components that exist in `fec-cms` and what this repository is attempting to import.
+
+If this happens, you may see the following error message:
+> Error: File to import not found or unreadable: ./node_modules/fec-cms/fec/fec/static/scss/components/stickybar.
+
+> Parent style sheet: […]/fec-pattern-library/static/scss/styles.scss
+
+If this happens, double-check that things you are trying to import in the pattern library actually exist in `fec-cms`.
+Look in https://github.com/18F/fec-cms/tree/develop/fec/fec/static/scss/components for the component specified by the error message.
+If you don’t find the component there, you can safely remove it from  […]/fec-pattern-library/static/scss/styles.scss on your branch, then save and execute `npm run build` again. The error message should no longer appear. 
+
 ## Front end asset management for components
 Component specific SCSS and JavaScript files are contained in the `public/` folder, and compiled files and assets are be served from the `public/` folder.
 
@@ -61,5 +74,3 @@ This command gets a list of icons and generates HTML markup for the custom docum
 
 ### "Hack" to get documentation pages to display custom styles
 Documentation pages (like `documentation/02-typography.md`) include hardcoded HTML to render hidden components so they can render custom FEC styles. Those components are defined in `components/01-basics/*`.
-
-

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ npm run-build-js
 Since the `fec-cms` repository is a dependency to this pattern library, there may be discrepancies between style components that exist in `fec-cms` and what this repository is attempting to import.
 
 If this happens, you may see the following error message:
-> Error: File to import not found or unreadable: ./node_modules/fec-cms/fec/fec/static/scss/components/stickybar.
+> Error: File to import not found or unreadable: ./node_modules/fec-cms/fec/fec/static/scss/components/[some-component].
 
 > Parent style sheet: […]/fec-pattern-library/static/scss/styles.scss
 
 If this happens, double-check that things you are trying to import in the pattern library actually exist in `fec-cms`.
 Look in https://github.com/18F/fec-cms/tree/develop/fec/fec/static/scss/components for the component specified by the error message.
-If you don’t find the component there, you can safely remove it from `[…]/fec-pattern-library/static/scss/styles.scss` on your branch, then save and execute `npm run build` again. The error message should no longer appear. 
+If you don’t find the component there, you can safely remove it from `[…]/fec-pattern-library/static/scss/styles.scss` on your branch, then save and execute `npm run build` again. The error message should no longer appear.
 
 ## Front end asset management for components
 Component specific SCSS and JavaScript files are contained in the `public/` folder, and compiled files and assets are be served from the `public/` folder.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm run-build-js
 
 Since the `fec-cms` repository is a dependency to this pattern library, there may be discrepancies between style components that exist in `fec-cms` and what this repository is attempting to import.
 
-If this happens, you may see the following error message:
+If this happens, you may see the following error message in your terminal:
 > Error: File to import not found or unreadable: ./node_modules/fec-cms/fec/fec/static/scss/components/[some-component].
 
 > Parent style sheet: […]/fec-pattern-library/static/scss/styles.scss


### PR DESCRIPTION
While trying to run the pattern library locally, I ran into an error that may happen again in the future. 

Since `fec-cms` is a dependency in this repo, any changes to styles there will be picked up by this repo, and may have discrepancies. This adds instructions for troubleshooting in that scenario. 

cc @johnnyporkchops & @patphongs 